### PR TITLE
Pass Chrome data/profile downward

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ async function main() {
         return;
     }
 
-    const chrome = new Chrome(settings.port, settings.timeout, settings.chromePath);
+    const chrome = new Chrome(settings.port, settings.timeout, settings.chromePath, settings.chromeUserDataDir, settings.chromeProfile);
     const log = fs.createWriteStream("focus-dt.log", { flags: "a" });
 
     addOnQuit(() => {


### PR DESCRIPTION
https://developer.chrome.com/blog/remote-debugging-port means that an alternative data profile is now required for focus-dt to work ☹️ 